### PR TITLE
Add Trackers on client side of webtorrent

### DIFF
--- a/app/js/lib/streamer.js
+++ b/app/js/lib/streamer.js
@@ -7,9 +7,20 @@ const Streamer = {
         if (Streamer.client === null) {
             Streamer.client = new (require('webtorrent'))({
                 maxConns: 40,
-                tracker: {
-                    wrtc: false
-                }
+                tracker: [
+                'udp://tracker.leechers-paradise.org:6969/announce',
+                'udp://tracker.coppersurfer.tk:6969/announce',
+                'udp://glotorrents.pw:6969/announce','udp://exodus.desync.com:6969/announce',
+                'udp://tracker.opentrackr.org:1337/announce',
+                'udp://9.rarbg.com:2710/announce',        
+                'udp://tracker.openbittorrent.com:80',       
+                'udp://tracker.publicbt.com:80/announce',        
+                'udp://tracker.empire-js.us:1337',       
+                'wss://tracker.openwebtorrent.com',       
+                'wss://tracker.fastcast.nz',        
+                'wss://tracker.btorrent.xyz'
+                ],
+                dht: true
             });
         }
         return Streamer.client;


### PR DESCRIPTION
Adding tracker the client side wont affect the magnet announcing its own trackers , 
but i noticed sometimes the magnet is malformed which throw announce []  and make it hard for torrenting